### PR TITLE
Feature/lesson materials 1n relationship

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,8 +120,8 @@ model Material {
   fileUrl      String?
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
-  lessonId     Int?
-  Lesson       Lesson?      @relation("LessonMaterials", fields: [lessonId], references: [id], onDelete: Cascade)
+  lessonId     Int
+  Lesson       Lesson       @relation("LessonMaterials", fields: [lessonId], references: [id], onDelete: Cascade)
 }
 
 model Forum {
@@ -224,7 +224,7 @@ model Lesson {
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
   Section   Section    @relation(fields: [sectionId], references: [id])
-  Materials Material[] @relation("LessonMaterials") 
+  Materials Material[] @relation("LessonMaterials")
 
   CompletedLessons CompletedLessons[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,14 +114,14 @@ model CommunityMembers {
   @@map("CommunityMembers")
 }
 
-// TODO: Make material have 1 to 1 relation with lesson and onCascde delete
 model Material {
   id           Int          @id @default(autoincrement())
   materialType MaterialType
   fileUrl      String?
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
-  Lessons      Lesson[]
+  lessonId     Int?
+  Lesson       Lesson?      @relation("LessonMaterials", fields: [lessonId], references: [id], onDelete: Cascade)
 }
 
 model Forum {
@@ -217,15 +217,14 @@ model Section {
 }
 
 model Lesson {
-  id         Int      @id @default(autoincrement())
-  name       String
-  notes      String?
-  materialId Int
-  sectionId  Int
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  Material   Material @relation(fields: [materialId], references: [id])
-  Section    Section  @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  id        Int        @id @default(autoincrement())
+  name      String
+  notes     String?
+  sectionId Int
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  Section   Section    @relation(fields: [sectionId], references: [id])
+  Materials Material[] @relation("LessonMaterials") 
 
   CompletedLessons CompletedLessons[]
 }

--- a/src/config/swagger/schemas.ts
+++ b/src/config/swagger/schemas.ts
@@ -5,56 +5,55 @@ export const schemas = {
       id: { type: 'integer' },
       name: { type: 'string' },
       notes: { type: 'string', nullable: true },
-      materialId: { type: 'integer' },
       sectionId: { type: 'integer' },
       createdAt: { type: 'string', format: 'date-time' },
       updatedAt: { type: 'string', format: 'date-time' },
+      materials: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/Material' },
+      },
+    },
+    example: {
+      id: 1,
+      name: 'Intro to Algebra',
+      notes: 'Basic concepts',
+      sectionId: 1,
+      createdAt: '2025-04-03T12:24:27.161Z',
+      updatedAt: '2025-04-03T12:24:27.161Z',
+      materials: [
+        {
+          id: 1,
+          materialType: 'VIDEO',
+          fileUrl: 'https://example.com/video.mp4',
+          createdAt: '2025-04-22T12:22:14.918Z',
+          updatedAt: '2025-04-22T12:22:14.918Z',
+          lessonId: 1,
+        },
+      ],
     },
   },
-  LessonWithMaterial: {
-    allOf: [
-      { $ref: '#/components/schemas/Lesson' },
-      {
-        type: 'object',
-        properties: {
-          Material: {
-            type: 'object',
-            properties: {
-              id: { type: 'integer' },
-              materialType: {
-                type: 'string',
-                enum: ['VIDEO', 'AUDIO', 'IMG', 'DOC', 'FILE'],
-              },
-              fileUrl: { type: 'string', format: 'uri' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-            },
-          },
-        },
+
+  Material: {
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      materialType: {
+        type: 'string',
+        enum: ['VIDEO', 'AUDIO', 'IMG', 'DOC', 'FILE'],
       },
-    ],
+      fileUrl: { type: 'string', format: 'uri' },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+    },
+    example: {
+      id: 7,
+      materialType: 'VIDEO',
+      fileUrl: 'https://example.com/video.mp4',
+      createdAt: '2025-04-03T12:39:14.561Z',
+      updatedAt: '2025-04-03T12:39:14.561Z',
+    },
   },
-  LessonWithSection: {
-    allOf: [
-      { $ref: '#/components/schemas/Lesson' },
-      {
-        type: 'object',
-        properties: {
-          Section: {
-            type: 'object',
-            properties: {
-              id: { type: 'integer' },
-              name: { type: 'string' },
-              description: { type: 'string', nullable: true },
-              classroomId: { type: 'integer' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-            },
-          },
-        },
-      },
-    ],
-  },
+
   CreateLessonInput: {
     type: 'object',
     properties: {
@@ -63,14 +62,25 @@ export const schemas = {
       sectionId: { type: 'integer' },
     },
     required: ['name', 'sectionId'],
+    example: {
+      name: 'Intro to Algebra',
+      notes: 'Basic concepts',
+      sectionId: 1,
+    },
   },
+
   UpdateLessonInput: {
     type: 'object',
     properties: {
       name: { type: 'string', minLength: 1, maxLength: 100 },
       notes: { type: 'string', maxLength: 5000, nullable: true },
     },
+    example: {
+      name: 'Updated Lesson Name',
+      notes: 'Updated notes for this lesson.',
+    },
   },
+
   CreateMaterialInput: {
     type: 'object',
     properties: {
@@ -81,6 +91,10 @@ export const schemas = {
       fileUrl: { type: 'string', format: 'uri' },
     },
     required: ['materialType', 'fileUrl'],
+    example: {
+      materialType: 'VIDEO',
+      fileUrl: 'https://example.com/video.mp4',
+    },
   },
   Section: {
     type: 'object',

--- a/src/config/swagger/swagger.config.ts
+++ b/src/config/swagger/swagger.config.ts
@@ -11,6 +11,20 @@ const swaggerOptions: swaggerJsdoc.Options = {
       version: '1.0.0',
       description: 'API Documentation with Swagger in TypeScript',
     },
+    tags: [
+      { name: 'Auth', description: 'Authentication endpoints for user login, registration, etc.' },
+      { name: 'User', description: 'Endpoints for managing users' },
+      { name: 'Profiles', description: 'Endpoints for user profiles' },
+      { name: 'Communities', description: 'Endpoints for managing communities' },
+      { name: 'Leaderboard', description: 'Endpoints for tracking and displaying leaderboard data' },
+      { name: 'Classrooms', description: 'Endpoints for managing classrooms' },
+      { name: 'Sections', description: 'Endpoints for managing sections' },
+      { name: 'Lessons', description: 'Endpoints for managing lessons' },
+      { name: 'Posts', description: 'Endpoints for creating and managing posts' },
+      { name: 'Comments', description: 'Endpoints for handling comments on posts' },
+      { name: 'Upload', description: 'Endpoints for file uploads' },
+      { name: 'Progress', description: 'Endpoints for managing lesson status and progress tracking' },
+    ],
     servers: [
       {
         url: `http://localhost:${port}/api/v1`,

--- a/src/repos/lesson.repo.ts
+++ b/src/repos/lesson.repo.ts
@@ -10,7 +10,7 @@ export const LessonRepo = {
         sectionId: id,
       },
       include: {
-        Material: true,
+        Materials: true,
       },
     })
     return lessons
@@ -20,7 +20,7 @@ export const LessonRepo = {
     const lesson = await prisma.lesson.findUnique({
       where: { id },
       include: {
-        Material: true,
+        Materials: true,
       },
     })
     return lesson
@@ -29,17 +29,16 @@ export const LessonRepo = {
   async createWithMaterial(
     data: z.infer<typeof CreateLessonWithMaterialSchema>,
   ) {
-    return prisma.$transaction(async (tx) => {
-      const material = await tx.material.create({ data: data.material })
-      const lesson = await tx.lesson.create({
-        data: {
-          ...data.lesson,
-          materialId: material.id,
+    const lesson = await prisma.lesson.create({
+      data: {
+        ...data.lesson,
+        Materials: {
+          create: data.materials,
         },
-        include: { Material: true },
-      })
-      return lesson
+      },
+      include: { Materials: true },
     })
+    return lesson
   },
 
   async delete(id: number) {
@@ -55,6 +54,7 @@ export const LessonRepo = {
     const updatedlesson = await prisma.lesson.update({
       where: { id },
       data,
+      include: { Materials: true },
     })
     return updatedlesson
   },

--- a/src/repos/material.repo.ts
+++ b/src/repos/material.repo.ts
@@ -9,7 +9,7 @@ export const MaterialRepo = {
   async findAll() {
     const materials = await prisma.material.findMany({
       include: {
-        Lessons: true,
+        Lesson: true,
       },
     })
     return materials
@@ -19,7 +19,7 @@ export const MaterialRepo = {
     const material = await prisma.material.findUnique({
       where: { id },
       include: {
-        Lessons: true,
+        Lesson: true,
       },
     })
     return material

--- a/src/repos/user.repo.ts
+++ b/src/repos/user.repo.ts
@@ -80,8 +80,8 @@ export const UserRepo = {
             CommentVote: true,
           },
         },
-      }
-    });
-    return result?._count;
-  }
-};
+      },
+    })
+    return result?._count
+  },
+}

--- a/src/routes/lesson.route.ts
+++ b/src/routes/lesson.route.ts
@@ -1,4 +1,3 @@
-// src/routes/lesson.route.ts
 import express from 'express'
 import {
   getLessonsBySectionId,
@@ -46,24 +45,6 @@ router.use(isAuthenticated)
  *                   type: array
  *                   items:
  *                     $ref: '#/components/schemas/Lesson'
- *             example:
- *               success: true
- *               message: "Lessons retrieved successfully"
- *               data:
- *                 - id: 1
- *                   name: "Intro to Algebra"
- *                   notes: "Basic concepts"
- *                   materialId: 6
- *                   sectionId: 1
- *                   createdAt: "2025-04-03T12:24:27.161Z"
- *                   updatedAt: "2025-04-03T12:24:27.161Z"
- *                 - id: 2
- *                   name: "Intro to Algebra 2"
- *                   notes: "Basic concepts"
- *                   materialId: 7
- *                   sectionId: 1
- *                   createdAt: "2025-04-03T12:39:14.561Z"
- *                   updatedAt: "2025-04-03T12:39:14.561Z"
  *       400:
  *         description: Invalid section ID
  *       500:
@@ -101,25 +82,7 @@ router.get('/sections/:sectionId', getLessonsBySectionId)
  *                   type: string
  *                   example: "Lesson retrieved successfully"
  *                 data:
- *                   $ref: '#/components/schemas/LessonWithSection'
- *             example:
- *               success: true
- *               message: "Lesson retrieved successfully"
- *               data:
- *                 id: 2
- *                 name: "Advanced Algebra"
- *                 notes: "Exploring advanced algebraic concepts."
- *                 materialId: 10
- *                 sectionId: 1
- *                 createdAt: "2023-10-01T10:00:00Z"
- *                 updatedAt: "2023-10-01T10:00:00Z"
- *                 Section:
- *                   id: 1
- *                   name: "Mathematics Fundamentals"
- *                   description: "A comprehensive guide to foundational math topics."
- *                   classroomId: 1
- *                   createdAt: "2023-10-01T10:00:00Z"
- *                   updatedAt: "2023-10-01T10:00:00Z"
+ *                   $ref: '#/components/schemas/Lesson'
  *       400:
  *         description: Invalid lesson ID
  *       404:
@@ -133,7 +96,7 @@ router.get('/:id', getLessonById)
  * @swagger
  * /lessons:
  *   post:
- *     summary: Create a new lesson with a new material in a single transaction
+ *     summary: Create a new lesson with new materials in a single operation
  *     tags: [Lessons]
  *     security:
  *       - bearerAuth: []
@@ -146,16 +109,10 @@ router.get('/:id', getLessonById)
  *             properties:
  *               lesson:
  *                 $ref: '#/components/schemas/CreateLessonInput'
- *               material:
- *                 $ref: '#/components/schemas/CreateMaterialInput'
- *           example:
- *             lesson:
- *               name: "Intro to Algebra"
- *               notes: "Basic concepts"
- *               sectionId: 1
- *             material:
- *               materialType: "VIDEO"
- *               fileUrl: "https://example.com/video.mp4"
+ *               materials:
+ *                 type: array
+ *                 items:
+ *                   $ref: '#/components/schemas/CreateMaterialInput'
  *     responses:
  *       201:
  *         description: Lesson created successfully
@@ -171,24 +128,7 @@ router.get('/:id', getLessonById)
  *                   type: string
  *                   example: "Lesson created successfully"
  *                 data:
- *                   $ref: '#/components/schemas/LessonWithMaterial'
- *             example:
- *               success: true
- *               message: "Lesson created successfully"
- *               data:
- *                 id: 131
- *                 name: "Intro to Algebra"
- *                 notes: "Basic concepts"
- *                 materialId: 121
- *                 sectionId: 1
- *                 createdAt: "2023-10-01T10:00:00Z"
- *                 updatedAt: "2023-10-01T10:00:00Z"
- *                 Material:
- *                   id: 121
- *                   materialType: "VIDEO"
- *                   fileUrl: "https://example.com/video.mp4"
- *                   createdAt: "2023-10-01T10:00:00Z"
- *                   updatedAt: "2023-10-01T10:00:00Z"
+ *                   $ref: '#/components/schemas/Lesson'
  *       400:
  *         description: Invalid input data
  *       500:
@@ -217,9 +157,6 @@ router.post('/', createLessonWithNewMaterial)
  *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/UpdateLessonInput'
- *           example:
- *             name: "Updated Lesson Name"
- *             notes: "Updated notes for this lesson."
  *     responses:
  *       200:
  *         description: Lesson updated successfully
@@ -236,17 +173,6 @@ router.post('/', createLessonWithNewMaterial)
  *                   example: "Lesson updated successfully"
  *                 data:
  *                   $ref: '#/components/schemas/Lesson'
- *             example:
- *               success: true
- *               message: "Lesson updated successfully"
- *               data:
- *                 id: 2
- *                 name: "Updated Lesson Name"
- *                 notes: "Updated notes for this lesson."
- *                 materialId: 10
- *                 sectionId: 1
- *                 createdAt: "2023-10-01T10:00:00Z"
- *                 updatedAt: "2023-10-02T12:00:00Z"
  *       400:
  *         description: Invalid lesson ID or input data
  *       404:
@@ -285,9 +211,9 @@ router.patch('/:id', updateLesson)
  *                 message:
  *                   type: string
  *                   example: "Lesson deleted successfully"
- *             example:
- *               success: true
- *               message: "Lesson deleted successfully"
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       400:
  *         description: Invalid lesson ID
  *       404:

--- a/src/utils/zod/lessonMaterialSchemes.ts
+++ b/src/utils/zod/lessonMaterialSchemes.ts
@@ -1,8 +1,10 @@
-import { object } from 'zod'
+import { z } from 'zod'
 import { CreateLessonSchema } from './lessonSchemes'
 import { CreateMaterialSchema } from './materialSchemes'
 
-export const CreateLessonWithMaterialSchema = object({
-  lesson: CreateLessonSchema,
-  material: CreateMaterialSchema,
-}).strict()
+export const CreateLessonWithMaterialSchema = z
+  .object({
+    lesson: CreateLessonSchema,
+    materials: z.array(CreateMaterialSchema),
+  })
+  .strict()

--- a/src/utils/zod/lessonSchemes.ts
+++ b/src/utils/zod/lessonSchemes.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { MaterialSchema } from './materialSchemes'
 
 const BaseLessonSchema = z.object({
   name: z
@@ -20,7 +21,7 @@ export const CreateLessonSchema = BaseLessonSchema.extend({
 
 export const LessonSchema = CreateLessonSchema.extend({
   id: z.number().int().positive().optional(),
-  materialId: z.number().int().positive(),
+  materials: z.array(MaterialSchema).optional(),
   createdAt: z.date().optional(),
   updatedAt: z.date().optional(),
 }).strict()


### PR DESCRIPTION
- Modified Prisma schema to establish 1:N relationship between Lesson and Material with cascading delete
- Updated createLessonWithNewMaterial to support creating multiple materials
- Removed materialId from Lesson model in Prisma schema
- Updated Swagger docs and Zod schemas to reflect 1:N relationship changes
- Moved examples from lesson route Swagger comments to schemas file
- Ordered Swagger tags logically by resource hierarchy