### PR TITLE
update Forum relation in Post model to prevent cascading delete

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,7 @@ model Post {
   updatedAt   DateTime   @updatedAt
   Comments    Comment[]
   Author      User       @relation(fields: [authorId], references: [id])
-  Forum       Forum      @relation(fields: [forumId], references: [id])
+  Forum       Forum      @relation(fields: [forumId], references: [id], onDelete: NoAction)
   PostVotes   PostVote[]
 }
 


### PR DESCRIPTION
This pull request introduces a minor update to the Prisma schema for the `Post` model. The change specifies the `onDelete` behavior for the `Forum` relation.

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL146-R146): Updated the `Forum` relation in the `Post` model to include `onDelete: NoAction`, ensuring no cascading delete occurs when a related `Forum` is deleted.