### PR TITLE
fix: resolve post comments retrieval & community deletion issue

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,7 +103,7 @@ model CommunityMembers {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   Role        Role
-  Community   Community @relation(fields: [communityId], references: [id])
+  Community   Community @relation(fields: [communityId], references: [id], onDelete: Cascade)
   User        User      @relation(fields: [userId], references: [id])
 
   @@id([communityId, userId])
@@ -127,7 +127,7 @@ model Forum {
   communityId Int
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
-  Community   Community @relation(fields: [communityId], references: [id])
+  Community   Community @relation(fields: [communityId], references: [id],  onDelete: Cascade)
   Posts       Post[]
 }
 

--- a/src/controllers/commentController.ts
+++ b/src/controllers/commentController.ts
@@ -9,7 +9,7 @@ import { upsertUserContribution } from '../services/contributionService'
 
 export const findAllComments = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
-    const comments = await CommentService.findAllComments(+req.params.id)
+    const comments = await CommentService.findAllComments(+req.params.postId)
     res
       .status(200)
       .json(ResponseHelper.success('Comments fetched successfully', comments))

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const swaggerSpecs = swaggerJsdoc(swaggerOptions)
 // CORS & JSON parsing
 app.use(
   cors({
-    origin: 'http://localhost:3000',
+    origin: process.env.CLIENT_URL || 'http://localhost:3000',
     credentials: true,
   }),
 )


### PR DESCRIPTION
- Fixed `get post comments` .
- Fixed `delete community` error caused by foreign key constraint violation.
  - Added `onDelete: Cascade` for `Community` ↔ `CommunityMembers` relation.
  - Added `onDelete: Cascade` for `Community` ↔ `Forum` relation.