### PR TITLE
fix post and comment delete auth

### DIFF
--- a/src/controllers/commentController.ts
+++ b/src/controllers/commentController.ts
@@ -59,7 +59,9 @@ export const updateComment = asyncHandler(
 
 export const deleteComment = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
-    await CommentService.deleteComment(+req.params.id)
+    const actualUserId = +req.claims!.id
+    const commentId = +req.params.id
+    await CommentService.deleteComment(actualUserId, commentId);
     res.status(200).json(ResponseHelper.success('Comment deleted successfully'))
   },
 )

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -49,8 +49,11 @@ export const updatePost = asyncHandler(async (req: Request, res: Response) => {
     .json(ResponseHelper.success('Post updated successfully', post))
 })
 
-export const deletePost = asyncHandler(async (req: Request, res: Response) => {
-  await PostService.deletePost(+req.params.id)
+// TODO here we need to check if the user is the owner of the post or moderator, or owner of the communty
+export const deletePost = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+  const actualUserId = +req.claims!.id
+  const postId = +req.params.id
+  await PostService.deletePost( actualUserId, postId  )
   res.status(204).json(ResponseHelper.success('Post deleted successfully'))
 })
 

--- a/src/repos/comment.repo.ts
+++ b/src/repos/comment.repo.ts
@@ -68,6 +68,7 @@ export const CommentRepo = {
         Author: {
           select: {
             username: true,
+            id: true,
             UserProfile: {
               select: {
                 profilePictureURL: true,
@@ -75,6 +76,10 @@ export const CommentRepo = {
             },
           },
         },
+        Post: {
+          select:{ Forum: {select  : {Community: {select : {id : true}}}}}
+        }
+        ,
         Children: true,
       },
     })
@@ -168,6 +173,73 @@ export const CommentRepo = {
       create: { userId, commentId, type },
       update: { type },
     });
-  }
+  },
+  // get comment Auth and Role
+  async getCommentAuthAndRole( userId: number,commentId: number,) {
+    const result = await prisma.comment.findUnique({
+      where: {
+        id: commentId,
+      },
+      select: {
+        authorId: true,
+        Post: {
+          select: {
+            Forum: {
+              select: {
+                 Community: {
+                  select: {
+                    CommunityMembers: {
+                      where: {
+                        userId: userId,
+                      },
+                      select: {
+                        Role: true,
+                      },
+                    }
+                },
+              },
+            },
+          },
+        },
+      },
+    }})
+    return result
+  }, 
+
+  
+  async getPostAuthorAndCommunity(userId: number, postId: number) {
+    const result = await prisma.post.findUnique({
+      where: { id: postId },
+      select: {
+
+        Author: {
+          select: { id: true },
+        },
+        Forum: {
+          select: {
+            Community: {
+              select : {id : true}
+            },
+          },
+        },
+      }
+
+
+    })
+    return result
+  },
+  // get role by communityId and userId
+  async getRoleByCommunityIdAndUserId(userId: number, communityId: number) {
+    const result = await prisma.communityMembers.findUnique({
+      where: {  communityId_userId: {
+        communityId,
+        userId,
+      }, },
+      select: {
+        Role: true,
+      },
+    })
+    return result
+  },
   
 }

--- a/src/repos/community.repo.ts
+++ b/src/repos/community.repo.ts
@@ -12,6 +12,21 @@ export const CommunityRepo = {
     })
     return results
   },
+  // get community by fourm id
+  async findByForumId(forumId: number) {
+    const result = await prisma.forum.findUnique({
+      where: { id: forumId },
+      include: {
+        Community: {
+          include: {
+            Tags: true,
+            Owner: true,
+          },
+        },
+      },
+    })
+    return result?.Community
+  },
 
   async create(community: z.infer<typeof CommunitySchema>, userId: number) {
     const { Tags, ...rest } = community

--- a/src/repos/post.repo.ts
+++ b/src/repos/post.repo.ts
@@ -196,4 +196,39 @@ export const PostRepo = {
 
     return results
   },
+  
+  async getPostAuthorAndCommunity(userId: number, postId: number) {
+    const result = await prisma.post.findUnique({
+      where: { id: postId },
+      select: {
+
+        Author: {
+          select: { id: true },
+        },
+        Forum: {
+          select: {
+            Community: {
+              select : {id : true}
+            },
+          },
+        },
+      }
+
+
+    })
+    return result
+  },
+  // get role by communityId and userId
+  async getRoleByCommunityIdAndUserId(userId: number, communityId: number) {
+    const result = await prisma.communityMembers.findUnique({
+      where: {  communityId_userId: {
+        communityId,
+        userId,
+      }, },
+      select: {
+        Role: true,
+      },
+    })
+    return result
+  },
 }

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -5,6 +5,10 @@ import { PostRepo } from '../repos/post.repo'
 import { PostSchema, PostUpdateSchema } from '../utils/zod/postSchemes'
 import { UserRepo } from '../repos/user.repo'
 import { VoteType, PostVote } from '@prisma/client';
+import { CommunityRepo } from '../repos/community.repo'
+import { CommunityMembersRepo } from '../repos/communityMember.repo'
+import { use } from 'passport'
+import { Role } from '@prisma/client'
 
 async function getPostsByForumId(forumId: number) {
 
@@ -58,12 +62,21 @@ async function updatePost(
   return await PostRepo.update(postId, validatedData)
 }
 
-async function deletePost(postId: number) {
-  // TODO issue if post deleted, it deletes the fourm too
+async function deletePost( userId: number,postId: number,) {
+
   if (!postId) throw new APIError('Missing postId', 404)
-  const postExist = await PostRepo.findById(postId)
-  if (!postExist) throw new APIError('Post not found', 404)
-  await PostRepo.delete(postId)
+
+  const post = await PostRepo.findById(postId)
+  if (!post) throw new APIError('Post not found', 404)
+
+  const AccessAndCommunity= await PostRepo.getPostAuthorAndCommunity(userId, postId);
+  if (!AccessAndCommunity) throw new APIError('Can not get the Access Info for this post', 404)
+  
+
+    if(AccessAndCommunity.Author.id !== userId )
+      throw new APIError('You are not allowed to delete this post', 403)
+
+  return post
 }
 
 async function upVotePost(


### PR DESCRIPTION
This pull request introduces changes to enhance authorization and role-based access control for comment and post deletion, along with updates to repository methods to support these functionalities. It ensures that only authorized users can delete posts or comments based on their roles or ownership.

### Authorization Enhancements:

* **Comment Deletion Authorization**: Updated `deleteComment` in `src/controllers/commentController.ts` and `src/services/commentService.ts` to require the `userId` of the requestor. Added checks to ensure only the comment author, post owner, or community owner/moderator can delete a comment. [[1]](diffhunk://#diff-d490b03a23e3e8b68c79f55675131514e441d00feff5029a0cd6f4b4ac1e08e4L62-R64) [[2]](diffhunk://#diff-8d7539868afc8764f069a33e4cba791f5926bbd38cc0c3e546077b9a9587e4e1L38-R60)
* **Post Deletion Authorization**: Updated `deletePost` in `src/controllers/postController.ts` and `src/services/postService.ts` to include `userId` in the deletion logic. Added validation to ensure that only the post owner or authorized users can delete a post. [[1]](diffhunk://#diff-a2fe1ac20bc519192738990af18cf76f36de72f8b3fd895997c7749ad388479cL52-R56) [[2]](diffhunk://#diff-83c9afdb7e4befaed306b2997df9103cea044643b1676b9d5f8d07247231be04L61-R79)

### Repository Updates:

* **Comment Repository**: Added methods `getCommentAuthAndRole`, `getPostAuthorAndCommunity`, and `getRoleByCommunityIdAndUserId` in `src/repos/comment.repo.ts` to fetch authorization and role details for comments and related posts.
* **Post Repository**: Added similar methods (`getPostAuthorAndCommunity` and `getRoleByCommunityIdAndUserId`) in `src/repos/post.repo.ts` to support post-related authorization checks.
* **Community Repository**: Introduced `findByForumId` in `src/repos/community.repo.ts` to retrieve community details by forum ID, including tags and ownership information.

### Data Enrichment:

* **Comment Data**: Updated `findCommentById` in `src/repos/comment.repo.ts` to include the `id` of the comment author and community details of the associated post.

These changes collectively strengthen the system's security by enforcing proper access control for critical operations.