### PR TITLE
Get posts of commuinties joined modified

### DIFF
--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -93,7 +93,7 @@ export const getAllPostContribByUser = asyncHandler(
 
 export const getAllPostsFromCommunitiesJoinedByUser = asyncHandler(
   async (req: AuthenticatedRequest, res: Response) => {
-    const posts = await PostService.getAllPostsFromCommunitiesJoinedByUser(+req.params.userId)
+    const posts = await PostService.getAllPostsFromCommunitiesJoinedByUser(+req.claims!.id)
     res
       .status(200)
       .json(ResponseHelper.success('Posts fetched successfully', posts))

--- a/src/routes/post.route.ts
+++ b/src/routes/post.route.ts
@@ -380,17 +380,10 @@ router.put('/downvote/:postId', isAuthenticated, downVotePost);
 
 /**
  * @swagger
- * /posts/feed/{userId}:
+ * /posts/me/feed:
  *   get:
- *     summary: Get feed by userId
+ *     summary: Get feed for the authenticated user
  *     tags: [Posts]
- *     parameters:
- *       - in: path
- *         name: userId
- *         required: true
- *         schema:
- *           type: integer
- *         description: Forum ID
  *     security:
  *       - bearerAuth: []
  *     responses:
@@ -449,9 +442,8 @@ router.put('/downvote/:postId', isAuthenticated, downVotePost);
  *                     avatarUrl: https://example.com/profile.jpg
  *       401:
  *         description: Unauthorized
- *       404:
- *         description: Forum not found
  */
-router.get('/feed/:userId', isAuthenticated, getAllPostsFromCommunitiesJoinedByUser)
+router.get('/me/feed', isAuthenticated, getAllPostsFromCommunitiesJoinedByUser)
+
 
 export default router

--- a/src/routes/post.route.ts
+++ b/src/routes/post.route.ts
@@ -377,7 +377,6 @@ router.put('/upvote/:postId', isAuthenticated, upVotePost);
  *         description: Server error
  */
 router.put('/downvote/:postId', isAuthenticated, downVotePost);
-
 /**
  * @swagger
  * /posts/me/feed:
@@ -442,7 +441,12 @@ router.put('/downvote/:postId', isAuthenticated, downVotePost);
  *                     avatarUrl: https://example.com/profile.jpg
  *       401:
  *         description: Unauthorized
+ *       403:
+ *         description: Forbidden — insufficient permissions
+ *       404:
+ *         description: Feed not found
  */
+
 router.get('/me/feed', isAuthenticated, getAllPostsFromCommunitiesJoinedByUser)
 
 

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -143,19 +143,12 @@ async function getAllPostContribByUser(userId: number) {
   }
 
 async function getAllPostsFromCommunitiesJoinedByUser(userId: number) {
-  // 1️⃣ Input validation
-  if (!userId) {
-    throw new APIError('Missing userId', 400);
-  }
 
-  // 2️⃣ Ensure user exists
-  const user = await UserRepo.findById(userId);
-  if (!user) {
-    throw new APIError('User not found', 404);
-  }
+  
 
   // 3️⃣ Fetch flat list of posts  
   const posts = await PostRepo.getPostsFromCommunitiesJoinedByUser(userId);
+
   if (!posts.length) {
     return []; 
   }


### PR DESCRIPTION
This pull request updates the post-related API endpoints and services to use the authenticated user's ID instead of requiring a `userId` parameter. It also refines the Swagger documentation and error handling for improved clarity and consistency.

### API endpoint updates:
* [`src/routes/post.route.ts`](diffhunk://#diff-4f4093e09c7b9b10368fddece32f94a66c1e601c17e9dabdcc2cf3247676fa06L380-L393): Modified the `/posts/feed/{userId}` endpoint to `/posts/me/feed`, removing the `userId` parameter and using the authenticated user's ID instead. Updated the Swagger documentation to reflect these changes. [[1]](diffhunk://#diff-4f4093e09c7b9b10368fddece32f94a66c1e601c17e9dabdcc2cf3247676fa06L380-L393) [[2]](diffhunk://#diff-4f4093e09c7b9b10368fddece32f94a66c1e601c17e9dabdcc2cf3247676fa06R444-R451)

### Service logic updates:
* [`src/services/postService.ts`](diffhunk://#diff-83c9afdb7e4befaed306b2997df9103cea044643b1676b9d5f8d07247231be04L146-R151): Removed input validation and user existence checks for `getAllPostsFromCommunitiesJoinedByUser` since the authenticated user's ID is now guaranteed to be valid.

### Controller updates:
* [`src/controllers/postController.ts`](diffhunk://#diff-a2fe1ac20bc519192738990af18cf76f36de72f8b3fd895997c7749ad388479cL96-R96): Updated `getAllPostsFromCommunitiesJoinedByUser` to use `req.claims!.id` instead of `req.params.userId` for fetching posts.